### PR TITLE
fix: switch to trailingSlash 'always' to stop Netlify 301 redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import tailwind from '@tailwindcss/vite';
 export default defineConfig({
   site: 'https://joepassmorefineart.com',
   output: 'static',
-  trailingSlash: 'never',
+  trailingSlash: 'always',
   build: { format: 'directory' },
   integrations: [
     sitemap({

--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -16,7 +16,7 @@ const items = paintings.map((p) => ({
     items.map((p, i) => (
       <li class="bg-surface">
         <a
-          href={`/paintings/${p.slug}`}
+          href={`/paintings/${p.slug}/`}
           data-painting-slug={p.slug}
           class="block aspect-[3/2] overflow-hidden hover:no-underline"
         >

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,10 +14,10 @@ import ThemeToggle from "./ThemeToggle.astro";
       aria-label="Primary"
       class="flex flex-wrap items-center justify-center gap-1 text-sm sm:gap-2"
     >
-      <a href="/about" class="rounded-md px-3 py-2 text-text hover:bg-border hover:no-underline"
+      <a href="/about/" class="rounded-md px-3 py-2 text-text hover:bg-border hover:no-underline"
         >About</a
       >
-      <a href="/contact" class="rounded-md px-3 py-2 text-text hover:bg-border hover:no-underline"
+      <a href="/contact/" class="rounded-md px-3 py-2 text-text hover:bg-border hover:no-underline"
         >Contact</a
       >
       <a

--- a/src/components/PaintingDetail.astro
+++ b/src/components/PaintingDetail.astro
@@ -49,8 +49,8 @@ const { painting, image, prev, next } = Astro.props;
   }
 
   <nav aria-label="Painting navigation" class="mt-8 flex items-center justify-between text-sm">
-    {prev ? <a href={`/paintings/${prev.slug}`}>← {prev.title ?? prev.alt}</a> : <span />}
+    {prev ? <a href={`/paintings/${prev.slug}/`}>← {prev.title ?? prev.alt}</a> : <span />}
     <a href="/" class="text-text-muted">Back to gallery</a>
-    {next ? <a href={`/paintings/${next.slug}`}>{next.title ?? next.alt} →</a> : <span />}
+    {next ? <a href={`/paintings/${next.slug}/`}>{next.title ?? next.alt} →</a> : <span />}
   </nav>
 </article>

--- a/src/components/SeoHead.astro
+++ b/src/components/SeoHead.astro
@@ -10,7 +10,10 @@ type Props = {
 };
 
 const { title, description, path, image, jsonLd } = Astro.props;
-const canonicalUrl = new URL(path, site.url).toString();
+// Match Astro's `trailingSlash: 'always'` so canonical/og:url agree with the
+// served URL and Netlify doesn't 301 them.
+const normalizedPath = path === "/" || path.endsWith("/") ? path : `${path}/`;
+const canonicalUrl = new URL(normalizedPath, site.url).toString();
 const ogImage = image
   ? new URL(image.src, site.url).toString()
   : new URL("/og-default.jpg", site.url).toString();

--- a/src/scripts/lightbox.ts
+++ b/src/scripts/lightbox.ts
@@ -133,7 +133,7 @@ class Lightbox {
       this.dialog.showModal();
     }
     if (push) {
-      history.pushState({ lb: true }, "", `/paintings/${slug}`);
+      history.pushState({ lb: true }, "", `/paintings/${slug}/`);
       this.pushedThisSession = true;
     }
     this.preloadNeighbors();
@@ -145,7 +145,7 @@ class Lightbox {
     this.current = i;
     const slug = this.slugs[i];
     this.swapImage(slug);
-    history.replaceState({ lb: true }, "", `/paintings/${slug}`);
+    history.replaceState({ lb: true }, "", `/paintings/${slug}/`);
     this.preloadNeighbors();
   }
 

--- a/tests/a11y.spec.ts
+++ b/tests/a11y.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from "@playwright/test";
 import AxeBuilder from "@axe-core/playwright";
 
-const pages = ["/", "/about", "/contact", "/paintings/121", "/paintings/001", "/404"];
+const pages = ["/", "/about/", "/contact/", "/paintings/121/", "/paintings/001/", "/404"];
 
 const themes = [
   {

--- a/tests/lightbox.spec.ts
+++ b/tests/lightbox.spec.ts
@@ -21,8 +21,8 @@ test("ArrowRight navigates to next painting", async ({ page }) => {
   await expect(page).toHaveURL(/\/paintings\/120/);
 });
 
-test("Direct visit to /paintings/042 renders standalone page (no lightbox)", async ({ page }) => {
-  await page.goto("/paintings/042");
+test("Direct visit to /paintings/042/ renders standalone page (no lightbox)", async ({ page }) => {
+  await page.goto("/paintings/042/");
   await expect(page.locator("article img")).toBeVisible();
   await expect(page.locator("#lightbox")).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary

- Search Console flagged sitemap URLs as **Page with redirect** because Astro emitted canonical/sitemap URLs without a trailing slash (e.g. `/about`), but Netlify serves the directory form (`/about/`) and 301s the bare path. Googlebot followed the redirect on every sitemap entry.
- Switched `trailingSlash` from `'never'` to `'always'` so sitemap, canonical, og:url, and internal links all match what Netlify actually serves.
- `SeoHead.astro` normalizes the path prop so callers don't have to remember the convention.

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test:unit` — 12/12 pass
- [x] `pnpm test` (Playwright Chromium + WebKit) — 34/34 pass
- [x] Built `dist/sitemap-0.xml` entries now use `/about/`, `/contact/`, `/paintings/NNN/`
- [x] Canonical and og:url tags in built HTML now match the trailing-slash form
- [ ] After merge + Netlify deploy: in Search Console, hit **Validate Fix** on the "Page with redirect" report and resubmit `https://joepassmorefineart.com/sitemap-index.xml`